### PR TITLE
Task/support heroku redis

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -14,7 +14,9 @@ from src.game_state_server import GameStateServer
 async def start_server() -> GameStateServer:
     room_store: RoomStore
     if config.use_redis:
-        room_store = await RedisRoomStore.obtain(config.redis_address)
+        room_store = await RedisRoomStore.obtain(
+            config.redis_address, config.redis_ssl_validation
+        )
     else:
         room_store = FileRoomStore(config.room_store_dir)
 

--- a/api/src/config.py
+++ b/api/src/config.py
@@ -2,14 +2,13 @@ import os
 from dataclasses import dataclass
 from enum import Enum
 
+from src.room_store import SSLValidation
+
 
 class Environment(Enum):
     DEV = 'dev'
     STAGING = 'staging'
     PROD = 'prod'
-
-
-_scout_key = os.environ.get('SCOUT_KEY')
 
 
 @dataclass
@@ -20,9 +19,12 @@ class Config:
     redis_address = os.environ['REDIS_URL']
     use_redis: bool = os.environ.get('USE_REDIS') == 'true'
     json_logs: bool = os.environ.get('JSON_LOGS') == 'true'
+    redis_ssl_validation: SSLValidation = SSLValidation[
+        os.environ.get('REDIS_SSL_VALIDATION', 'default').upper()
+    ]
     scout_config = {
         'name': f'ttbud ({environment.value})',
-        'key': _scout_key,
+        'key': os.environ.get('SCOUT_KEY'),
         'monitor': os.environ.get('SCOUT_MONITOR') == 'true',
     }
     log_config = {

--- a/api/src/room_store.py
+++ b/api/src/room_store.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 import os
 import json
+import ssl
+from enum import Enum
+from ssl import SSLContext
 from typing import (
     Protocol,
     Iterable,
@@ -8,6 +11,7 @@ from typing import (
     List,
     Dict,
     AsyncIterator,
+    Union,
 )
 from abc import abstractmethod
 from dataclasses import asdict
@@ -82,13 +86,36 @@ def _room_key(room_id: str) -> str:
     return f'room:{room_id}'
 
 
+class SSLValidation(Enum):
+    # No SSL at all. Free heroku redis instances (which we use for staging) do not
+    # support SSL
+    NONE = 'none'
+    # Use SSL, but disable cert verification.
+    # Heroku's _paid_ redis plans (which we use in production) have self-signed certs
+    # without a consistent key we can trust :(. If we ever start handling data that's
+    # even remotely private, we'll have to find a better solution
+    SELF_SIGNED = 'self_signed'
+    # Full SSL verification
+    DEFAULT = 'default'
+
+
 class RedisRoomStore(RoomStore):
     def __init__(self, redis: Redis) -> None:
         self.redis = redis
 
     @staticmethod
-    async def obtain(address: str) -> RedisRoomStore:
-        redis = await aioredis.create_redis_pool(address)
+    async def obtain(address: str, ssl_validation: SSLValidation) -> RedisRoomStore:
+        ssl_context: Union[SSLContext, bool]
+        if ssl_validation == SSLValidation.SELF_SIGNED:
+            ssl_context = SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.VerifyMode.CERT_NONE
+        elif ssl_validation == SSLValidation.NONE:
+            ssl_context = False
+        else:
+            ssl_context = ssl.create_default_context()
+
+        redis = await aioredis.create_redis_pool(address, ssl=ssl_context)
         return RedisRoomStore(redis)
 
     async def get_all_room_ids(self) -> AsyncIterator[str]:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       PORT: ${API_WEBSOCKET_PORT}
       ROOM_STORE_DIR: /var/ttbud/rooms
       USE_REDIS:
+      # We don't set up ssl certs for redis local dev
+      REDIS_SSL_VALIDATION: none
       REDIS_URL: redis://db
     volumes:
       - rooms:/var/ttbud/rooms


### PR DESCRIPTION
Heroku redis free doesn't support SSL at all. Heroku redis paid only supports self-signed certs, so we have to allow configuring that. It makes everyone sad.