### PR TITLE
Remove unnecessary -- before yarn test args

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
             - JEST_JUNIT_OUTPUT_DIR: test-results
             - REACT_APP_DOMAIN: localhost
             - REACT_APP_API_WEBSOCKET_PORT: 1234
-          command: yarn run test -- --reporters=default --reporters=jest-junit
+          command: yarn run test --reporters=default --reporters=jest-junit
       - store_test_results:
           path: test-results
   release-staging-web:


### PR DESCRIPTION
Yarn doesn't require "--" before test args, and in a later version the
"--" will be passed to jest directly
