### PR TITLE
Reduce docker image footprint

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,20 +1,45 @@
-FROM python:3.9
-
+FROM python:3.9-slim as base
 RUN useradd --create-home appuser
-RUN mkdir /app
-WORKDIR /app
 USER appuser
 
-RUN pip install poetry
-ENV PATH="/home/appuser/.local/bin:${PATH}"
+WORKDIR /home/appuser/app
 
-RUN poetry config virtualenvs.create false
-ADD --chown=appuser:appuser pyproject.toml poetry.lock ./
+FROM base as builder
 
+USER root
+RUN apt-get update \
+    && apt-get install -y \
+        g++ \
+        gcc \
+        libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
+USER appuser
+
+ENV PATH="/home/appuser/.local/bin:${PATH}" \
+    # We're always going to use the version built into the docker image
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    # pip cache is useless in a docker build because we always only ever run
+    # the install once
+    PIP_NO_CACHE_DIR=1
+
+RUN pip install --user poetry
+# Create a venv so it's easy to copy everything over to the final image
+# Creating our own venv instead of letting poetry create one automatically
+# lets us dictate the venv location
+RUN python -m venv /home/appuser/venv
+
+COPY --chown=appuser:appuser pyproject.toml poetry.lock ./
 ARG DEV=false
-RUN if [ ${DEV} = "true" ]; then poetry install; else poetry install --no-dev; fi
+RUN . /home/appuser/venv/bin/activate && \
+    poetry install --no-root --no-interaction --no-ansi $(test "$DEV" != "true" && echo "--no-dev")
 
-ADD --chown=appuser:appuser . ./
+COPY --chown=appuser:appuser . ./
+
+FROM base
+
+COPY --chown=appuser:appuser --from=builder /home/appuser/venv /home/appuser/venv/
+COPY --chown=appuser:appuser --from=builder /home/appuser/app /home/appuser/app/
+
+ENV PATH=/home/appuser/venv/bin:$PATH
 EXPOSE 5000
-
 CMD ["gunicorn", "-c", "gunicorn.conf.py", "main:app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
       context: api
       args:
         DEV: "true"
-    working_dir: /app/
     command: python main.py
     environment:
       ENVIRONMENT:
@@ -24,7 +23,7 @@ services:
       REDIS_SSL_VALIDATION: none
       REDIS_URL: redis://db
     volumes:
-      - ./api:/app
+      - ./api:/home/appuser/app
       - ./certs:/certs
     ports:
       - ${API_WEBSOCKET_PORT}:${API_WEBSOCKET_PORT}


### PR DESCRIPTION
Reducing our footprint helps reduce our attack surface by reducing the
number of programs installed on the production docker image and makes
spinning up new nodes faster

We use two strategies to reduce our build footprint
* Use the -slim variant of the python images to reduce the number of
installed dependencies at the operating system level
* Use a docker multi-stage build so that OS dependencies we need to build
our python dependencies don't make it into the production image
