### PR TITLE
[Merged by Bors] - Fix toolbars jumping when settings clicked

### DIFF
--- a/web/src/ui/settings/Settings.tsx
+++ b/web/src/ui/settings/Settings.tsx
@@ -186,6 +186,7 @@ const PureSettings: React.FC<Props> = memo(
           anchorEl={anchorEl}
           anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
           transformOrigin={{ vertical: "bottom", horizontal: "right" }}
+          disableScrollLock={true}
         >
           <div className={classes.popoverContainer}>
             <List


### PR DESCRIPTION
When the settings popup opened the scrollbars were disabled which caused
the toolbars to jump. To fix it the settings popup no longer disables the
scrollbars.
