### PR TITLE
Specify the number of jest workers in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,10 @@ jobs:
             - JEST_JUNIT_OUTPUT_DIR: test-results
             - REACT_APP_DOMAIN: localhost
             - REACT_APP_API_WEBSOCKET_PORT: 1234
-          command: yarn run test --reporters=default --reporters=jest-junit
+          # Have to manually set max workers because jest detects the wrong
+          # number of cpu cores in circleci
+          # https://github.com/facebook/jest/issues/5239#issuecomment-355867359
+          command: yarn run test --reporters=default --reporters=jest-junit --maxWorkers=2
       - store_test_results:
           path: test-results
   release-staging-web:


### PR DESCRIPTION
Jest incorrectly detects the number of available CPUs in circleci, and
schedules way to many workers, slowing down the tests.

See: https://github.com/facebook/jest/issues/5239#issuecomment-355867359
