### PR TITLE
[Merged by Bors] - Remove useless react imports

### DIFF
--- a/web/src/drag/Draggable.fixture.tsx
+++ b/web/src/drag/Draggable.fixture.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Draggable from "./Draggable";
 import DraggableSquare from "../ui/__stories__/DragAwareSquare";
 import { configureStore, getDefaultMiddleware } from "@reduxjs/toolkit";

--- a/web/src/drag/Draggable.test.tsx
+++ b/web/src/drag/Draggable.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Draggable from "./Draggable";
 import { ContentType } from "../types";
 import { DraggableType } from "./DragStateTypes";

--- a/web/src/drag/Droppable.fixture.tsx
+++ b/web/src/drag/Droppable.fixture.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Draggable from "./Draggable";
 import Droppable from "./Droppable";
 import Square from "../ui/__stories__/Square";

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import ReactDOM from "react-dom";
 import * as serviceWorker from "./serviceWorker";
 import { DomDroppableMonitor } from "./drag/DroppableMonitor";

--- a/web/src/ui/about/About.fixture.tsx
+++ b/web/src/ui/about/About.fixture.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import About from "./About";
 import noop from "../../util/noop";
 

--- a/web/src/ui/about/About.tsx
+++ b/web/src/ui/about/About.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   Button,
   Dialog,

--- a/web/src/ui/app/App.test.tsx
+++ b/web/src/ui/app/App.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
 import { DomDroppableMonitor } from "../../drag/DroppableMonitor";

--- a/web/src/ui/board/Board.fixture.tsx
+++ b/web/src/ui/board/Board.fixture.tsx
@@ -1,5 +1,4 @@
 import { configureStore, getDefaultMiddleware } from "@reduxjs/toolkit";
-import React from "react";
 import { Provider, useSelector } from "react-redux";
 import DndContext from "../../drag/DndContext";
 import dragReducer from "../../drag/drag-slice";

--- a/web/src/ui/confirm/ConfirmationDialog.tsx
+++ b/web/src/ui/confirm/ConfirmationDialog.tsx
@@ -6,8 +6,6 @@ import {
   DialogActions,
   Button,
 } from "@material-ui/core";
-import React from "react";
-
 interface Props {
   open: boolean;
   title: string;

--- a/web/src/ui/connection-state/ConnectionNotifier.fixture.tsx
+++ b/web/src/ui/connection-state/ConnectionNotifier.fixture.tsx
@@ -1,6 +1,5 @@
 import { PureConnectionNotifier } from "./ConnectionNotifier";
 import { ConnectionStateType } from "./connection-state-slice";
-import React from "react";
 import noop from "../../util/noop";
 import { ConnectionError } from "../../network/BoardStateApiClient";
 

--- a/web/src/ui/connection-state/ConnectionNotifier.test.tsx
+++ b/web/src/ui/connection-state/ConnectionNotifier.test.tsx
@@ -1,6 +1,5 @@
 import { render } from "@testing-library/react";
 import { ConnectionStateType } from "./connection-state-slice";
-import React from "react";
 import { PureConnectionNotifier } from "./ConnectionNotifier";
 import "@testing-library/jest-dom";
 import noop from "../../util/noop";

--- a/web/src/ui/connection-state/ConnectionNotifier.tsx
+++ b/web/src/ui/connection-state/ConnectionNotifier.tsx
@@ -3,7 +3,6 @@ import {
   ConnectionStateType,
   Disconnected,
 } from "./connection-state-slice";
-import React from "react";
 import Alert from "@material-ui/lab/Alert";
 import RefreshIcon from "@material-ui/icons/Cached";
 import { connect } from "react-redux";

--- a/web/src/ui/search/SearchDialog.fixture.tsx
+++ b/web/src/ui/search/SearchDialog.fixture.tsx
@@ -1,6 +1,5 @@
 import SearchDialog from "./SearchDialog";
 import { ICONS } from "../icons";
-import React from "react";
 import { DomDroppableMonitor } from "../../drag/DroppableMonitor";
 import { configureStore, getDefaultMiddleware } from "@reduxjs/toolkit";
 import dragReducer from "../../drag/drag-slice";

--- a/web/src/ui/settings/Settings.test.tsx
+++ b/web/src/ui/settings/Settings.test.tsx
@@ -1,5 +1,4 @@
 import { render } from "@testing-library/react";
-import React from "react";
 import { PureSettings } from "./Settings";
 import noop from "../../util/noop";
 import userEvent from "@testing-library/user-event";

--- a/web/src/ui/token/Character.fixture.tsx
+++ b/web/src/ui/token/Character.fixture.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { DEFAULT_CHARACTER_ICONS } from "../icons";
 import Character from "./Character";
 import { ContentType, IconContents } from "../../types";

--- a/web/src/ui/token/Character.test.tsx
+++ b/web/src/ui/token/Character.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render } from "@testing-library/react";
 import Character from "./Character";
 import { ContentType } from "../../types";

--- a/web/src/ui/token/Floor.fixture.tsx
+++ b/web/src/ui/token/Floor.fixture.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import Floor from "./Floor";
 import { ContentType } from "../../types";
 import { WALL_ICON } from "../icons";

--- a/web/src/ui/token/Floor.test.tsx
+++ b/web/src/ui/token/Floor.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render } from "@testing-library/react";
 import { ContentType } from "../../types";
 import { WALL_ICON } from "../icons";

--- a/web/src/ui/token/Floor.tsx
+++ b/web/src/ui/token/Floor.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Pos2d from "../../util/shape-math";
 import { ContentType, TokenContents } from "../../types";
 import FloorIcon from "./FloorIcon";

--- a/web/src/ui/token/Ping.fixture.tsx
+++ b/web/src/ui/token/Ping.fixture.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Ping from "./Ping";
 
 export default <Ping x={0} y={0} />;

--- a/web/src/ui/tour/ShortcutText.tsx
+++ b/web/src/ui/tour/ShortcutText.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
 
 const useStyles = makeStyles({

--- a/web/src/ui/tour/Tour.tsx
+++ b/web/src/ui/tour/Tour.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Reactour from "reactour";
 import steps from "./steps";
 import TourPopup from "./TourPopup";

--- a/web/src/ui/tour/TourPopup.test.tsx
+++ b/web/src/ui/tour/TourPopup.test.tsx
@@ -1,6 +1,5 @@
 import { render } from "@testing-library/react";
 import TourPopup from "./TourPopup";
-import React from "react";
 import noop from "../../util/noop";
 import userEvent from "@testing-library/user-event";
 

--- a/web/src/ui/tour/TourPopup.tsx
+++ b/web/src/ui/tour/TourPopup.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import CloseIcon from "@material-ui/icons/Close";
 import {
   Button,

--- a/web/src/ui/tour/steps.tsx
+++ b/web/src/ui/tour/steps.tsx
@@ -1,6 +1,5 @@
 import { ReactourStep } from "reactour";
 import isMac from "../../util/isMac";
-import React from "react";
 import ShortcutText from "./ShortcutText";
 import TourPopupContent from "./TourPopupContent";
 

--- a/web/src/ui/transition/NoopTransition.tsx
+++ b/web/src/ui/transition/NoopTransition.tsx
@@ -1,6 +1,4 @@
 import { Transition } from "react-transition-group";
-import React from "react";
-
 interface Props {
   in?: boolean;
 }

--- a/web/src/ui/tray/CharacterTray.fixture.tsx
+++ b/web/src/ui/tray/CharacterTray.fixture.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import dragReducer from "../../drag/drag-slice";
 import { configureStore, getDefaultMiddleware } from "@reduxjs/toolkit";
 import { DomDroppableMonitor } from "../../drag/DroppableMonitor";

--- a/web/src/ui/tray/FloorTray.fixture.tsx
+++ b/web/src/ui/tray/FloorTray.fixture.tsx
@@ -1,5 +1,4 @@
 import { configureStore, getDefaultMiddleware } from "@reduxjs/toolkit";
-import React from "react";
 import { Provider } from "react-redux";
 import DndContext from "../../drag/DndContext";
 import dragReducer from "../../drag/drag-slice";


### PR DESCRIPTION
With React 17 we don't need them anymore:
https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
