### PR TITLE
[Merged by Bors] - Use immer's produce instead of manually copying

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,7 @@
     "@types/uuid": "8.3.0",
     "@types/webpack-env": "1.16.0",
     "fp-ts": "2.10.5",
+    "immer": "^9.0.3",
     "io-ts": "2.2.16",
     "jest-junit": "12.2.0",
     "jest-websocket-mock": "2.2.1",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -8605,6 +8605,11 @@ immer@^9.0.1:
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.2.tgz#83e4593df9914acaecfd9fac6a8601ef44d883fc"
   integrity sha512-mkcmzLtIfSp40vAqteRr1MbWNSoI7JE+/PB36FNPoSfJ9RQRmNKuTYCjKkyXyuq3Dgn07HuJBrwJd4ZSk2yUbw==
 
+immer@^9.0.3:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.3.tgz#146e2ba8b84d4b1b15378143c2345559915097f4"
+  integrity sha512-mONgeNSMuyjIe0lkQPa9YhdmTv8P19IeHV0biYhcXhbd5dhdB9HSK93zBpyKjp6wersSUgT5QyU0skmejUVP2A==
+
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"


### PR DESCRIPTION
Simplifies the code and allows us to avoid copies in the event that only
some values change
