### PR TITLE
[Merged by Bors] - Reduce max distance moved for long taps

### DIFF
--- a/web/src/ui/util/useLongTap.test.tsx
+++ b/web/src/ui/util/useLongTap.test.tsx
@@ -35,7 +35,7 @@ it("does not trigger for drags", async () => {
   const { getByText } = render(<LongTapTest onLongTap={cb} />);
   const target = getByText("Touch Target");
   await tap(target, { action: "down", pos: { x: 0, y: 0 } });
-  await fireEvent.pointerMove(target, {
+  fireEvent.pointerMove(target, {
     pointerType: "touch",
     isPrimary: true,
     clientX: MAX_MOVE_LONG_TAP_PX + 1,

--- a/web/src/ui/util/useLongTap.ts
+++ b/web/src/ui/util/useLongTap.ts
@@ -3,7 +3,7 @@ import { assert } from "../../util/invariants";
 import Pos2d, { distance } from "../../util/shape-math";
 
 // Maximum distance in pixels your finger can move to still be considered a long tap
-export const MAX_MOVE_LONG_TAP_PX = 10;
+export const MAX_MOVE_LONG_TAP_PX = 5;
 export const LONG_TAP_MS = 250;
 
 interface State {


### PR DESCRIPTION
At 10 pixels, it was too easy to accidentally ping while dragging around
