### PR TITLE
[Merged by Bors] - Disable unit tests in the master build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,13 +183,16 @@ jobs:
 default-filter: &DEFAULT_FILTER
   filters:
     branches:
-      # bors ng uses these branches to stage merges for pending PRs, they
-      # shouldn't be built until bors moves them to the "staging" branch
-      # https://bors.tech/documentation/getting-started/
       ignore:
+        # bors ng uses these branches to stage merges for pending PRs, they
+        # shouldn't be built until bors moves them to the "staging" branch
+        # https://bors.tech/documentation/getting-started/
         - staging.tmp
         - trying.tmp
         - staging-squash-merge.tmp
+        # We don't need to run unit tests on master, because bors ensures
+        # they ran on the same commit in staging
+        - master
 workflows:
   version: 2
   all:


### PR DESCRIPTION
We don't need to run unit tests on master, because bors ensures
they ran on the same commit in staging
