### PR TITLE
[Merged by Bors] - Remove unused async_util functions

### DIFF
--- a/api/src/util/amerge.py
+++ b/api/src/util/amerge.py
@@ -9,8 +9,6 @@ from typing import (
     Generic,
 )
 
-from src.util.async_util import anext
-
 _T = TypeVar('_T')
 
 

--- a/api/src/util/async_util.py
+++ b/api/src/util/async_util.py
@@ -26,25 +26,6 @@ async def end_task(task: Task) -> None:
         pass
 
 
-async def anext(iterator: AsyncIterator[_T]) -> _T:
-    """
-    Retrieve the next item from the `iterator`.
-    If the iterator is exhausted, StopIteration is raised.
-    """
-    return await iterator.__anext__()
-
-
-def aiter(iterable: AsyncIterable[_T]) -> AsyncIterator[_T]:
-    """Return the iterator object for the given iterable"""
-    return iterable.__aiter__()
-
-
-async def all_items(q: asyncio.Queue[_T]) -> AsyncIterator[_T]:
-    """Create an indefinite iterator that contains all items the queue contains"""
-    while True:
-        yield await q.get()
-
-
 async def to_coroutine(awaitable: Awaitable[_T]) -> _T:
     """Transform any awaitable into a coroutine"""
     return await awaitable

--- a/api/tests/util/test_async_util.py
+++ b/api/tests/util/test_async_util.py
@@ -6,7 +6,7 @@ from typing import TypeVar, AsyncIterator, Union
 import pytest
 
 from src.util.amerge import amerge, CompleteCondition
-from src.util.async_util import async_collect, anext, race
+from src.util.async_util import async_collect, race
 from tests.helpers import to_async
 
 


### PR DESCRIPTION
anext and aiter have made it into the standard library,
and all_items wasn't being used
