### PR TITLE
Remove staging release dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,8 +264,6 @@ workflows:
           <<: *EXIT_IF_NOT_MERGE_QUEUE
       - release-staging:
           requires:
-            - web
-            - api
             - build-staging-web
           <<: *EXIT_IF_NOT_MERGE_QUEUE
       - e2e-staging:


### PR DESCRIPTION
Staging release doesn't strictly depend on tests passing. This will
speed up several runs now that the staging release job has to run every
time instead of just when we're actually planning to release to staging
