### PR TITLE
Remove staging serial-group

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,12 +259,10 @@ workflows:
       - build-staging-web:
           <<: *EXIT_IF_NOT_MERGE_QUEUE
       - release-staging:
-          serial-group: << pipeline.project.slug >>/deploy-staging
           requires:
             - build-staging-web
           <<: *EXIT_IF_NOT_MERGE_QUEUE
       - e2e-staging:
-          serial-group: << pipeline.project.slug >>/deploy-staging
           requires:
             - release-staging
           <<: *EXIT_IF_NOT_MERGE_QUEUE


### PR DESCRIPTION
The circleci locking mechanism is deadlocking with the queuing process
in github's merge queue. A similar result can be achieved by setting
github's merge queue build concurrency to one, which I have done instead
